### PR TITLE
Update DC_OPENAIRE.pm

### DIFF
--- a/cfg/plugins/EPrints/Plugin/Export/DC_OPENAIRE.pm
+++ b/cfg/plugins/EPrints/Plugin/Export/DC_OPENAIRE.pm
@@ -3,6 +3,7 @@ package EPrints::Plugin::Export::DC_OPENAIRE;
 use base qw/ EPrints::Plugin::Export::DC /;
 
 use strict;
+use Time::Piece;
 
 sub convert_dataobj
 {
@@ -25,30 +26,37 @@ sub convert_dataobj
 		push @dcdata, [ "relation", "info:eu-repo/grantAgreement/EC/" . $eprint->get_value( "eu_project_fundingprogramme") . "/" . $eprint->get_value( "eu_project_id" ) . "/EU/" . $eprint->get_value( "eu_project_name" ) . "/" . $eprint->get_value( "eu_project_acronym" ) ] if($eprint->exists_and_set( "eu_project_id" ));
 		
 		my $embargoed = 0;
-	    my @documents = $eprint->get_all_documents();
-	    foreach ( @documents )
-	    {
+		my @documents = $eprint->get_all_documents();
+		foreach ( @documents )
+		{
 			if( !$_->is_public)
 			{
-	            my $embargo = $_->get_value("date_embargo");
+				my $embargo = $_->get_value("date_embargo");
 
 				if($embargo != "")
 				{
 					$embargoed = 1;
 
-		            # EPrints embargo date may be just be a year or year/month.
-		            # Need to normalise and format as per guidelines
-	            	$embargo = $embargo . "-01-01" if (length $embargo == 4);
-	            	$embargo = $embargo . "-01" if (length $embargo == 7);
+					# EPrints embargo date may be just be a year or year/month.
+					# Need to normalise and format as per guidelines
+					if( length $embargo == 4)
+					{
+						$embargo = $embargo . "-12-31";
+					}
+					elsif( length $embargo == 7)
+					{
+						my $tp = Time::Piece->strptime( $embargo, "%Y-%m" );
+						$embargo = "$embargo-".$tp->month_last_day;
+					}
 
-		            push @dcdata, [ "date", "info:eu-repo/date/embargoEnd/" . $embargo ] ;
-	        	}
+					push @dcdata, [ "date", "info:eu-repo/date/embargoEnd/" . $embargo ] ;
+				}
 			}
-	    }
+		}
 
-	    if($embargoed)
-	    {
-	    	# Override anything set in the metadata if we have an embargo in force
+		if($embargoed)
+		{
+			# Override anything set in the metadata if we have an embargo in force
 			push @dcdata, [ "rights", "info:eu-repo/semantics/embargoedAccess" ];
 		}
 		else


### PR DESCRIPTION
Correct logic for embargo end dates.
The logic in `<eprints_root>/bin/lift_embargos` results in:

* embargo_date with just a year is made public on 01/01 of the next year
* embargo_date with year and month is made public on the 1st day of the next month
* full embargo date is made available on that date

As OpenAire wants an 'embargo end date', we need to work out the last day of the month specified.
There are 'clever' (mathematical) ways to do this in Perl - but I think the most understandable is to use Time::Piece.

As Time::Piece is a core Perl module, I don't think this additional requirement should cause any problems?

(see also: https://github.com/eprintsug/openaire-compliance/pull/2)